### PR TITLE
case for when dbs are empty

### DIFF
--- a/pages/artworks/index.tsx
+++ b/pages/artworks/index.tsx
@@ -28,6 +28,9 @@ export async function getServerSideProps() {
     const parsedArtworks = JSON.parse(JSON.stringify(artworkArray));
     numArtworks = parsedArtworks.length;
     randomized = parsedArtworks.sort(() => 0.5 - Math.random());
+  } else {
+    numArtworks = 0;
+    randomized = []
   }
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,7 +28,6 @@ export default function Home({
 
 export async function getStaticProps() {
   const homeContent = await getHomeContent(4, 8); // inputs are number of returned projects and artworks respectively
-
   let bannerProjects;
   let featuredProject;
   let bannerArtworks;
@@ -39,8 +38,11 @@ export async function getStaticProps() {
     featuredProject = parsedProjects[3]; // ensures it is not a banner project
     const parsedArtworks = JSON.parse(JSON.stringify(homeContent.artworks));
     bannerArtworks = parsedArtworks;
+  } else {
+    featuredProject = {}
+    bannerProjects = []
+    bannerArtworks = []
   }
-
   return {
     props: {
       featuredProject: featuredProject,

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -34,6 +34,8 @@ export async function getServerSideProps() {
   if (projectsArray) {
     const parsedProjects = JSON.parse(JSON.stringify(projectsArray));
     randomized = parsedProjects.sort(() => 0.5 - Math.random());
+  } else {
+    randomized = [];
   }
 
   return {


### PR DESCRIPTION
In the event the mongo instance is empty, one receives errors like so.
```
rror - SerializableError: Error serializing `.featuredProject` returned from `getStaticProps` in "/".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
    at isSerializable (/home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/lib/is-serializable-props.js:36:19)
    at /home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/lib/is-serializable-props.js:43:66
    at Array.every (<anonymous>)
    at isSerializable (/home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/lib/is-serializable-props.js:40:39)
    at Object.isSerializableProps (/home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/lib/is-serializable-props.js:63:12)
    at Object.renderToHTML (/home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/server/render.js:440:93)
    at async doRender (/home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/server/base-server.js:720:34)
    at async cacheEntry.responseCache.get.incrementalCache.incrementalCache (/home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/server/base-server.js:837:28)
    at async /home/thdev/Documents/intheory-beta-mvp/node_modules/next/dist/server/response-cache/index.js:83:36 {
  page: '/'
}
```
This pr offers serialisable defaults for devs getting started in the dev environment